### PR TITLE
Ajustement footer mobile

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -422,7 +422,19 @@ a:hover {
 
 @media (max-width: 767.98px) {
   .site-footer-top-inner {
-    flex-direction: column;
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1.5rem;
+  }
+
+  .site-footer-brand {
+    max-width: 55%;
+  }
+
+  .site-footer-region {
+    flex: 1;
+    font-size: 0.85rem;
   }
 
   .site-footer-bottom-inner {


### PR DESCRIPTION
Améliorer l’affichage mobile du footer en plaçant le logo à gauche et les informations de contact à droite sur une seule ligne.
Issue #49 