### PR TITLE
Champ objet dans le formulaire de contact artisan

### DIFF
--- a/api/src/controllers/contact.controller.js
+++ b/api/src/controllers/contact.controller.js
@@ -55,6 +55,15 @@ exports.createContactMessage = async (req, res) => {
       .toString()
       .trim();
 
+    // Objet : le front envoie objet
+    let objet = (
+      body.objet ??
+      body.subject ??
+      ""
+    )
+      .toString()
+      .trim();
+
     // Message : le front envoie contenu_message
     let message = (
       body.contenu_message ??
@@ -73,21 +82,29 @@ exports.createContactMessage = async (req, res) => {
       prenom,
       nom,
       email,
+      objet,
       message,
       id_artisan,
     });
 
     // ====== VALIDATION BASIQUE ======
 
-    if (!prenom || !nom || !email || !message) {
+    if (!prenom || !nom || !email || !objet || !message) {
       return res.status(400).json({
-        error: "Les champs prénom, nom, email et message sont obligatoires.",
+        error:
+          "Les champs prénom, nom, email, objet et message sont obligatoires.",
       });
     }
 
     if (!isValidEmail(email)) {
       return res.status(400).json({
         error: "L'adresse email n'est pas valide.",
+      });
+    }
+
+    if (objet.length < 3 || objet.length > 255) {
+      return res.status(400).json({
+        error: "L'objet doit contenir entre 3 et 255 caractères.",
       });
     }
 
@@ -116,6 +133,7 @@ exports.createContactMessage = async (req, res) => {
       nom_expediteur: `${prenom} ${nom}`.trim(),
 
       email_expediteur: email,
+      objet,
       contenu_message: message,
 
       id_artisan: artisan ? artisan.id_artisan ?? artisan.id : null,
@@ -128,7 +146,7 @@ exports.createContactMessage = async (req, res) => {
     try {
       await sendContactEmail({
         artisan,
-        payload: { prenom, nom, email, message },
+        payload: { prenom, nom, email, objet, message },
       });
     } catch (mailError) {
       console.error("Erreur durant l'envoi du mail de contact :", mailError);

--- a/api/src/models/message_contact.js
+++ b/api/src/models/message_contact.js
@@ -26,6 +26,12 @@ const MessageContact = sequelize.define(
       },
     },
 
+    // Objet du message
+    objet: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+
     // Contenu complet du message
     contenu_message: {
       type: DataTypes.TEXT,

--- a/api/src/services/mailService.js
+++ b/api/src/services/mailService.js
@@ -28,25 +28,31 @@ async function sendContactEmail({ artisan, payload }) {
     `${artisan?.prenom ?? ""} ${artisan?.nom ?? ""}`.trim()) ||
   "un artisan";
 
-  const subject = `Nouveau message pour ${artisanName}`;
+  const objet = (payload.objet || "").trim();
+  const subjectBase = objet || "Nouveau message";
+  const subject = `[Trouve ton artisan] ${subjectBase} — ${artisanName}`;
   const plainText = `
-Vous avez reçu un nouveau message via la plateforme "Trouve ton artisan".
+  Vous avez reçu un nouveau message via la plateforme "Trouve ton artisan".
 
-Artisan concerné : ${artisanName}
-Nom du demandeur : ${payload.prenom} ${payload.nom}
-Email du demandeur : ${payload.email}
+  Artisan concerné : ${artisanName}
+  Nom du demandeur : ${payload.prenom} ${payload.nom}
+  Email du demandeur : ${payload.email}
+  Objet : ${objet || "—"}
 
-Message :
-${payload.message}
+  Message :
+  ${payload.message}
 
-Merci de répondre au demandeur sous 48h.
+  Merci de répondre au demandeur sous 48h.
   `.trim();
 
   const html = `
     <p>Vous avez reçu un nouveau message via la plateforme <strong>« Trouve ton artisan »</strong>.</p>
     <p><strong>Artisan concerné :</strong> ${artisanName}</p>
-    <p><strong>Demandeur :</strong> ${payload.prenom} ${payload.nom}<br>
-    <strong>Email :</strong> <a href="mailto:${payload.email}">${payload.email}</a></p>
+    <p>
+      <strong>Demandeur :</strong> ${payload.prenom} ${payload.nom}<br>
+      <strong>Email :</strong> <a href="mailto:${payload.email}">${payload.email}</a><br>
+      <strong>Objet :</strong> ${objet || "—"}
+    </p>
     <p><strong>Message :</strong></p>
     <p>${payload.message.replace(/\n/g, "<br>")}</p>
     <p>Merci de répondre au demandeur sous 48h.</p>

--- a/bdd/script_creation.sql
+++ b/bdd/script_creation.sql
@@ -72,6 +72,7 @@ CREATE TABLE message_contact (
   id_message INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
   nom_expediteur VARCHAR(150) NOT NULL,
   email_expediteur VARCHAR(255) NOT NULL,
+  objet VARCHAR(255) NOT NULL,
   contenu_message TEXT NOT NULL,
   id_artisan INT UNSIGNED NULL,
   id_specialite INT UNSIGNED NULL,

--- a/frontend/src/pages/ArtisanDetail.jsx
+++ b/frontend/src/pages/ArtisanDetail.jsx
@@ -14,6 +14,7 @@ export default function ArtisanDetail() {
   const [prenom, setPrenom] = useState("");
   const [nom, setNom] = useState("");
   const [emailContact, setEmailContact] = useState("");
+  const [objet, setObjet] = useState("");
   const [message, setMessage] = useState("");
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState("");
@@ -128,9 +129,10 @@ export default function ArtisanDetail() {
     const trimmedPrenom = prenom.trim();
     const trimmedNom = nom.trim();
     const trimmedEmail = emailContact.trim();
+    const trimmedObjet = objet.trim();
     const trimmedMessage = message.trim();
 
-    if (!trimmedPrenom || !trimmedNom || !trimmedEmail || !trimmedMessage) {
+    if (!trimmedPrenom || !trimmedNom || !trimmedEmail || !trimmedObjet || !trimmedMessage) {
       setSendError("Merci de remplir tous les champs obligatoires.");
       return;
     }
@@ -142,6 +144,7 @@ export default function ArtisanDetail() {
         prenom: trimmedPrenom,
         nom: trimmedNom,
         email: trimmedEmail,
+        objet: trimmedObjet,
         message: trimmedMessage,
       };
 
@@ -155,6 +158,7 @@ export default function ArtisanDetail() {
       setPrenom("");
       setNom("");
       setEmailContact("");
+      setObjet("");
       setMessage("");
     } catch (error) {
       console.error(
@@ -329,6 +333,23 @@ export default function ArtisanDetail() {
                     className="form-control"
                     value={emailContact}
                     onChange={(e) => setEmailContact(e.target.value)}
+                    required
+                  />
+                </div>
+
+                <div className="mb-2">
+                  <label
+                    htmlFor="artisan-contact-objet"
+                    className="form-label"
+                  >
+                    Objet *
+                  </label>
+                  <input
+                    id="artisan-contact-objet"
+                    type="text"
+                    className="form-control"
+                    value={objet}
+                    onChange={(e) => setObjet(e.target.value)}
                     required
                   />
                 </div>

--- a/frontend/src/pages/Contact.jsx
+++ b/frontend/src/pages/Contact.jsx
@@ -14,6 +14,7 @@ export default function Contact() {
   const [prenom, setPrenom] = useState("");
   const [nom, setNom] = useState("");
   const [email, setEmail] = useState("");
+  const [objet, setObjet] = useState("");
   const [message, setMessage] = useState("");
 
   const [sending, setSending] = useState(false);
@@ -52,9 +53,10 @@ export default function Contact() {
     const trimmedPrenom = prenom.trim();
     const trimmedNom = nom.trim();
     const trimmedEmail = email.trim();
+    const trimmedObjet = objet.trim();
     const trimmedMessage = message.trim();
 
-    if (!trimmedPrenom || !trimmedNom || !trimmedEmail || !trimmedMessage) {
+    if (!trimmedPrenom || !trimmedNom || !trimmedEmail || !trimmedObjet || !trimmedMessage) {
       setSendError("Merci de remplir tous les champs obligatoires.");
       return;
     }
@@ -66,6 +68,7 @@ export default function Contact() {
         prenom: trimmedPrenom,
         nom: trimmedNom,
         email: trimmedEmail,
+        objet: trimmedObjet,
         message: trimmedMessage,
       };
 
@@ -81,6 +84,7 @@ export default function Contact() {
       setPrenom("");
       setNom("");
       setEmail("");
+      setObjet("");
       setMessage("");
     } catch (error) {
       console.error("Erreur envoi contact :", error);
@@ -154,6 +158,20 @@ export default function Contact() {
                     className="form-control"
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
+                    required
+                  />
+                </div>
+
+                <div className="col-12">
+                  <label htmlFor="contact-objet" className="form-label">
+                    Objet *
+                  </label>
+                  <input
+                    id="contact-objet"
+                    type="text"
+                    className="form-control"
+                    value={objet}
+                    onChange={(e) => setObjet(e.target.value)}
                     required
                   />
                 </div>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -91,6 +91,8 @@ export async function sendContactMessage(form) {
 
     email_expediteur: form.email_expediteur ?? form.email ?? "",
 
+    objet: form.objet ?? form.subject ?? "",
+
     contenu_message:
       form.contenu_message ??
       form.message ??


### PR DESCRIPTION
Ajout du champ objet dans les formulaires de contact (fiche artisan + page contact).
Remontée du champ objet dans le service front, l’API et la BDD.
Utilisation de objet comme sujet d’email et enregistrement dans message_contact.
Issue #55 